### PR TITLE
Add sort by timestamps to Key Phrases example

### DIFF
--- a/audio-intelligence/key_phrases.ipynb
+++ b/audio-intelligence/key_phrases.ipynb
@@ -143,6 +143,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Sort highlights by timestamps\n",
+    "\n",
+    "By default, the highlights are sorted by rank, with the highlight with the highest rank being the first.\n",
+    "\n",
+    "If you want to sort the highlights by timestamps, you can use the built-in [sorted](https://docs.python.org/3/library/functions.html#sorted) function in Python with the `key` argument being the `start` attribute of the highlight's first timestamp."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "key_phrases = transcript.auto_highlights.results\n",
+    "\n",
+    "key_phrases = sorted(key_phrases, key=lambda x: x.timestamps[0].start)\n",
+    "\n",
+    "for result in key_phrases:\n",
+    "    print(f\"Highlight: {result.text}, Count: {result.count}, Rank: {result.rank}, Timestamps: {result.timestamps}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Understanding the Response\n",
     "\n",
     "The `auto_highlights_result` key in the response contains a list of all the highlights found int the transcription text. For each entry, the results include the text of the phrase or word detected (`text`), how many times it occurred in the text (`count`), its relevancy score (`rank`), and a list of all the timestamps (`timestamps`), in milliseconds, in the audio where the phrase or word is spoken.\n",


### PR DESCRIPTION
This PR adds a new section to the key phrases guide that shows how to sort the results by timestamps. 