### PR TITLE
fix(lemur): Update Token Cost Guide to Accurately Reflect LeMUR Input Token Cost

### DIFF
--- a/lemur/counting-tokens.ipynb
+++ b/lemur/counting-tokens.ipynb
@@ -15,13 +15,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Counting Transcript Tokens Before Processing with LeMUR\n",
+    "# Estimating Input Token Costs for LeMUR\n",
     "\n",
     "AssemblyAI's [LeMUR](https://www.assemblyai.com/blog/lemur/) (Leveraging Large Language Models to Understand Recognized Speech) framework is a powerful way to extract insights from transcripts generated from audio and video files. Given how varied the type of input and output could be for these use cases, the [pricing](https://www.assemblyai.com/pricing) for LeMUR is based on input and output tokens.\n",
     "\n",
-    "Output tokens can be controlled via LeMUR's [max_output_tokens](https://www.assemblyai.com/docs/api-reference/lemur) parameter, but how do you determine the amount of input tokens you'll be sending to LeMUR? How many tokens does an audio file contain? This Colab will show you how to calculate that information to help predict LeMUR's cost ahead of time.\n",
+    "Output tokens can be controlled via LeMUR's [max_output_tokens](https://www.assemblyai.com/docs/lemur/advanced/customize-parameters#change-the-maximum-output-size) parameter, but how do you determine the amount of input tokens you'll be sending to LeMUR? How many tokens does an audio file contain? This Colab will show you how to calculate that information to help predict LeMUR's cost ahead of time.\n",
     "\n",
-    "To get started, you'll need to install the popular `tiktoken` tokenizer alongside the AssemblyAI Python SDK, which we'll use to transcribe our file."
+    "To get started, you'll need to install the AssemblyAI Python SDK, which we'll use to transcribe our file."
    ]
   },
   {
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -U assemblyai tiktoken"
+    "%pip install -U assemblyai"
    ]
   },
   {
@@ -47,7 +47,6 @@
    "outputs": [],
    "source": [
     "import assemblyai as aai\n",
-    "import tiktoken\n",
     "\n",
     "aai.settings.api_key = \"API_KEY_HERE\""
    ]
@@ -74,7 +73,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we'll load our encoding, which specifies how text is coverted into tokens. For LeMUR, we'll be using the `cl100k_base` encoding to count our tokens. Then we can encode our transcript text and determine how many tokens will be passed into LeMUR alongside a prompt."
+    "LeMUR counts tokens based solely on character count, so we'll be using Python's built-in `len()` function to count the characters in our transcript."
    ]
   },
   {
@@ -86,44 +85,45 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "995\n"
+      "4928\n"
      ]
     }
    ],
    "source": [
-    "encoding = tiktoken.get_encoding(\"cl100k_base\")\n",
+    "character_count = len(transcript.text)\n",
     "\n",
-    "num_tokens = len(encoding.encode(transcript.text))\n",
-    "\n",
-    "print(num_tokens)"
+    "print(character_count)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For this specific file, we got 995 tokens. LeMUR's pricing is calculated per 1K tokens, but is prorated for amounts below this."
+    "For this specific file, we got 4,928 tokens. LeMUR's pricing is calculated per 1K tokens, and is prorated for amounts below this."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "$0.016915\n"
+      "LeMUR Default | LeMUR Claude 2.1 Cost: $0.07392\n",
+      "LeMUR Basic Cost: $0.009856\n"
      ]
     }
    ],
    "source": [
-    "prorate_ratio = num_tokens / 1000\n",
+    "count_in_thousands = character_count / 1000\n",
     "\n",
-    "cost = 0.017 * prorate_ratio\n",
+    "default_cost = 0.015 * count_in_thousands\n",
+    "basic_cost = 0.002 * count_in_thousands\n",
     "\n",
-    "print(f\"${cost}\")"
+    "print(f\"LeMUR Default | LeMUR Claude 2.1 Cost: ${default_cost}\")\n",
+    "print(f\"LeMUR Basic Cost: ${basic_cost}\")"
    ]
   },
   {
@@ -150,7 +150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
LeMUR doesn't use a traditional tokenizer (like `tiktoken`) to tokenize the input text and determine pricing. We go off of character count, so this guide needs to reflect that. Our prices for LeMUR and LeMUR docs have also changed since this guide was first written, so those should be updated as well.