### PR TITLE
Correct max_output_size param name

### DIFF
--- a/lemur/counting-tokens.ipynb
+++ b/lemur/counting-tokens.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "AssemblyAI's [LeMUR](https://www.assemblyai.com/blog/lemur/) (Leveraging Large Language Models to Understand Recognized Speech) framework is a powerful way to extract insights from transcripts generated from audio and video files. Given how varied the type of input and output could be for these use cases, the [pricing](https://www.assemblyai.com/pricing) for LeMUR is based on input and output tokens.\n",
     "\n",
-    "Output tokens can be controlled via LeMUR's [max_output_tokens](https://www.assemblyai.com/docs/lemur/advanced/customize-parameters#change-the-maximum-output-size) parameter, but how do you determine the amount of input tokens you'll be sending to LeMUR? How many tokens does an audio file contain? This Colab will show you how to calculate that information to help predict LeMUR's cost ahead of time.\n",
+    "Output tokens can be controlled via LeMUR's [max_output_size](https://www.assemblyai.com/docs/lemur/advanced/customize-parameters#change-the-maximum-output-size) parameter, but how do you determine the amount of input tokens you'll be sending to LeMUR? How many tokens does an audio file contain? This Colab will show you how to calculate that information to help predict LeMUR's cost ahead of time.\n",
     "\n",
     "To get started, you'll need to install the AssemblyAI Python SDK, which we'll use to transcribe our file."
    ]
@@ -130,7 +130,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we've determined how much the input tokens from our transcript will cost with LeMUR, not including the tokens of our prompt. To calculate how much the input tokens will cost for your prompt, or how much the amount of output tokens you're limited to will cost, you can follow this same method, replacing `transcript.text` with the text of your prompt, or `num_tokens` with the `max_output_tokens` amount you've specified to LeMUR."
+    "Here we've determined how much the input tokens from our transcript will cost with LeMUR, not including the tokens of our prompt. To calculate how much the input tokens will cost for your prompt, or how much the amount of output tokens you're limited to will cost, you can follow this same method, replacing `transcript.text` with the text of your prompt, or `num_tokens` with the `max_output_size` amount you've specified to LeMUR."
    ]
   }
  ],


### PR DESCRIPTION
The LeMUR customized parameter is called `max_output_size` and not `max_output_tokens` according to the docs [here](https://www.assemblyai.com/docs/api-reference/lemur/question-answer) for example