### PR TITLE
Updating ALD Nano Workflow Cookbook to Use `language_confidence_threshold`

### DIFF
--- a/core-transcription/automatic-language-detection-route-nano-model.ipynb
+++ b/core-transcription/automatic-language-detection-route-nano-model.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "# Automatic Language Detection: Route to Nano Speech Model if Language Confidence is Low\n",
     "\n",
-    "This guide will show you how to use AssemblyAI's API to resubmit a request to the Nano Speech Model if the Best Speech Model Automatic Language Detection's `language_confidence` is below a certain threshold. As the Nano Speech Model supports 99 languages compared to 17 by the Best Speech Model, this workflow will route transcripts to the most appropriate language code if it does not fit within the Best Support Languages. The following code uses the Python SDK. \n",
+    "This guide will show you how to use AssemblyAI's API to resubmit a request to the Nano Speech Model if the Best Speech Model Automatic Language Detection's `language_confidence_threshold` isn't met. As the Nano Speech Model supports 99 languages compared to 17 by the Best Speech Model, this workflow will route transcripts to the identified language code if it does not fit within our Best supported languages. The following code uses the Python SDK.\n",
     "\n",
     "## Get Started\n",
     "\n",
@@ -59,7 +59,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Define a `Transcriber`, an `audio_url` set to a link to the audio file, and a `TranscriptionConfig` with `language_detection=True`. For this Cookbook, to emphasize the Speech Model selected, we will also specify `speech_model=\"best\"`. Then create a transcript."
+    "Define a `Transcriber`, an `audio_url` set to a link to the audio file, and a `TranscriptionConfig` with `language_detection=True`. For this Cookbook, to emphasize the Speech Model selected, we will also specify `speech_model=\"best\"`. Finally, we need to define our `language_confidence_threshold`. For the purposes of this example, we'll set it to 0.8, representing 80% confidence.\n",
+    "\n",
+    "If a transcript ends up with a `language_confidence` below this value, the transcript will error out, and we'll return the identified language that had the highest confidence. This is useful for cases where the language identified isn't supported by our Best speech model, wherein confidence will be very low, but the language is supported via Nano, where you can programmatically route this file."
    ]
   },
   {
@@ -70,7 +72,8 @@
    "source": [
     "transcriber = aai.Transcriber()\n",
     "audio_url = (\"https://example.org/audio.mp3\")\n",
-    "config = aai.TranscriptionConfig(speech_model=\"best\", language_detection=True)\n",
+    "\n",
+    "config = aai.TranscriptionConfig(speech_model=aai.SpeechModel.best, language_detection=True, language_confidence_threshold=0.8)\n",
     "transcript = transcriber.transcribe(audio_url, config)"
    ]
   },
@@ -78,7 +81,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Define a `confidence_threshold`, which should be set to a number between 0 and 1. The `confidence_threshold` will be the barometer for determining if the transcript needs to be run again in the Nano Speech model. Through our tests, we've found 0.8 and below to be inaccurate but you can adjust this as you like."
+    "If your transcript errors out with a `language_confidence`-related error, you can parse our error message to resubmit the file to Nano with the recommended language code. Since the original request to Best failed with an error, there is no cost for this process, and re-routing the file to Nano will transcribe the file at a lower cost than Best as well.\n",
+    "\n",
+    "For the purposes of this guide, we'll include an example of what this error message looks like so you can choose to build your own parsing logic should you wish."
    ]
   },
   {
@@ -87,48 +92,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "confidence_threshold = 0.8"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If there is an error with the transcript, print out the error. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if transcript.error:\n",
-    "    print(transcript.error)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "After the initial transcript is run and there is no error, check if the `language_confidence` on the transcript is less than the `confidence_threshold`. Also, the `language_code` should be `en` as this is the default `language_code` if the `best` Speech Model does not recognize the language.  If this is all true, a message is printed saying that the transcript is being rerun, the transcript is run again with the `speech_model` set to the `nano`, and the transcript ID and text of the new transcript are both printed. If this is false, then the transcript ID and text of the original transcript are printed."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if transcript.json_response[\"language_confidence\"] < confidence_threshold and transcript.json_response[\"language_code\"] == \"en\":\n",
-    "    print(f\"Low confidence ({transcript.json_response['language_confidence']}) that {transcript.json_response['language_code']} is the correct language. Running transcript again with speech_model set to nano and Automatic Language Detection.\")\n",
-    "    new_config = aai.TranscriptionConfig(speech_model=\"nano\", language_detection=True)\n",
-    "    new_transcript = transcriber.transcribe(audio_url, new_config)\n",
-    "    print(f\"Transcript ID: {new_transcript.id}\")\n",
-    "    print(new_transcript.text)\n",
-    "else:\n",
-    "    print(f\"Transcript ID: {transcript.id}\")\n",
+    "import re\n",
+    "\n",
+    "error = \"detected language 'sv', confidence 0.22, is below the requested confidence threshold value of 0.8\"  # Example message. Normally you'd access this error via transcript.error.\n",
+    "\n",
+    "# Check if this is an ALD confidence threshold error.\n",
+    "if \"below the requested confidence threshold value\" in error:\n",
+    "    match = re.search(r\"detected language '(\\w+)'\", error)\n",
+    "    detected_language = match.group(1)\n",
+    "    \n",
+    "    new_config = aai.TranscriptionConfig(speech_model=aai.SpeechModel.nano, language_code=detected_language)\n",
+    "\n",
+    "    transcript = transcriber.transcribe(audio_url, new_config)\n",
+    "\n",
     "    print(transcript.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The resulting transcript will now be in the language we identified with our ALD model, and will have been routed to the correct `speech_model` with no human intervention needed and at a lower cost than having it incorrectly transcribed via Best without this form of error checking."
    ]
   }
  ],
@@ -148,7 +132,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.13.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Previously we had a Cookbook recommending that we define a `language_confidence` variable to check the returned `language_confidence` of a completed transcript and determine if that file should be re-routed to Nano with ALD. This is for cases where we may have ended up transcribing a file on Best in English as a fallback if the detected language was unsupported by Best.

A better workflow is to use our native `language_confidence_threshold` parameter to define a threshold at which we should error out the transcript server-side. The error message that we return will contain the language that was identified as well as it's confidence score, meaning that customers not only save on cost since the original run will error out rather than completing and providing a bad transcript, but that customers can also use this returned `language_code` to re-submit the file to Nano without ALD and at a lower cost.