### PR TITLE
fix: fix EU endpoint URL

### DIFF
--- a/core-transcription/how_to_use_the_eu_endpoint.ipynb
+++ b/core-transcription/how_to_use_the_eu_endpoint.ipynb
@@ -64,7 +64,7 @@
         "url = \"https://api.assemblyai.com\"\n",
         "\n",
         "# EU endpoint - just change the base URL\n",
-        "url = \"https://eu.api.assemblyai.com\""
+        "url = \"https://api.eu.assemblyai.com\""
       ]
     },
     {
@@ -109,7 +109,7 @@
         "const url = 'https://api.assemblyai.com'\n",
         "\n",
         "// EU endpoint - just change the base URL\n",
-        "const url = 'https://eu.api.assemblyai.com'"
+        "const url = 'https://api.eu.assemblyai.com'"
       ],
       "metadata": {
         "id": "ivPAfMjpMbFG"
@@ -135,7 +135,7 @@
         "\n",
         "const client = new AssemblyAI({\n",
         "  apiKey: process.env.ASSEMBLYAI_API_KEY,\n",
-        "  baseUrl: \"https://eu.api.assemblyai.com\"  // Set the baseUrl to the EU endpoint\n",
+        "  baseUrl: \"https://api.eu.assemblyai.com\"  // Set the baseUrl to the EU endpoint\n",
         "});"
       ],
       "metadata": {
@@ -163,7 +163,7 @@
         "\n",
         "AssemblyAI aai = AssemblyAI.builder()\n",
         "    .apiKey(\"YOUR_API_KEY\")\n",
-        "    .environment(Environment.custom(\"https://eu.api.assemblyai.com\")) // Set the environment to the EU endpoint\n",
+        "    .environment(Environment.custom(\"https://api.eu.assemblyai.com\")) // Set the environment to the EU endpoint\n",
         "    .build();"
       ],
       "metadata": {
@@ -230,7 +230,7 @@
         "\n",
         "    client := assemblyai.NewClientWithOptions(\n",
         "        assemblyai.WithAPIKey(apiKey),\n",
-        "        assemblyai.WithBaseURL(\"https://eu.api.assemblyai.com\"), // Set the base URL to the EU endpoint\n",
+        "        assemblyai.WithBaseURL(\"https://api.eu.assemblyai.com\"), // Set the base URL to the EU endpoint\n",
         "    )\n",
         "}"
       ],


### PR DESCRIPTION
There was previously the wrong URL for the EU endpoint "eu.api.assemblyai.com" which has now been corrected to "api.eu.assemblyai.com".