### PR TITLE
Update detecting-low-confidence-words.md

### DIFF
--- a/core-transcription/detecting-low-confidence-words.md
+++ b/core-transcription/detecting-low-confidence-words.md
@@ -23,7 +23,7 @@ const client = new AssemblyAI({
 Next create the transcript with your audio file, either via local audio file or URL (AssemblyAI's servers need to be able to access the URL, make sure the URL links to a downloadable file).
 
 ```javascript
-const transcript = await client.transcripts.create({
+const transcript = await client.transcripts.transcribe({
   audio_url: './sample.mp4',
 })
 ```


### PR DESCRIPTION
Updated transcription call to use proper `transcribe` method (perhaps `create` was the method name in an older version of the SDK?)